### PR TITLE
Fix deprecation warnings in ES 2.0+

### DIFF
--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -871,13 +871,28 @@ module Chewy
     #   UsersIndex::User.filter{ age <= 42 }.delete_all
     #
     def delete_all
+      if Runtime.version >= '2.0'
+        plugins = Chewy.client.nodes.info(plugins: true)['nodes'].values.map { |item| item['plugins'] }.flatten
+        raise PluginMissing, 'install delete-by-query plugin' unless plugins.find { |item| item['name'] == 'delete-by-query' }
+      end
+
       request = chain { criteria.update_options simple: true }.send(:_request)
+
       ActiveSupport::Notifications.instrument 'delete_query.chewy',
         request: request, indexes: _indexes, types: _types,
         index: _indexes.one? ? _indexes.first : _indexes,
         type: _types.one? ? _types.first : _types do
-          Chewy.client.delete_by_query(request)
-      end
+          if Runtime.version >= '2.0'
+            path = Elasticsearch::API::Utils.__pathify(
+              Elasticsearch::API::Utils.__listify(request[:index]),
+              Elasticsearch::API::Utils.__listify(request[:type]),
+              '/_query'
+            )
+            Chewy.client.perform_request(Elasticsearch::API::HTTP_DELETE, path, {}, request[:body]).body
+          else
+            Chewy.client.delete_by_query(request)
+          end
+        end
     end
 
     # Find all records matching a query.


### PR DESCRIPTION
@chanks I'm working on the upgrade to ES 2.0+. This is a simple update to the `delete_all` method taken verbatim from the [current master](https://github.com/toptal/chewy/blob/bcd4cc9d62a8a7856c638fd46c520dd067336143/lib/chewy/query.rb#L942). The goal is to prevent a deprecation warning (actually 12 of them 😄) for every spec.