### PR TITLE
[v2.x] update fetch_indexed_objects logic

### DIFF
--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -181,7 +181,8 @@ module Chewy
             break if result['hits']['hits'].empty?
 
             result['hits']['hits'].map do |hit|
-              indexed_objects[hit['_id']] = { parent: hit['fields']['_parent'] }
+              parent = hit.has_key?('_parent') ? hit['_parent'] : hit['fields']['_parent']
+              indexed_objects[hit['_id']] = { parent: parent }
             end
           end
 


### PR DESCRIPTION
@chanks hopefully the last fix for a breaking change introduced in ES 2.x. The original commit is [here](https://github.com/toptal/chewy/commit/6be27270c936450568fd83f1bae5e95c9d43a079).