### PR TITLE
Fix routing_missing_exception on delete with parent missing

### DIFF
--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -97,7 +97,8 @@ module Chewy
 
           if self.root_object.parent_id
             existing_object = entry[:_id].present? && indexed_objects && indexed_objects[entry[:_id].to_s]
-            entry.merge!(parent: existing_object[:parent]) if existing_object
+            return [] unless existing_object
+            entry.merge!(parent: existing_object[:parent])
           end
 
           [{ delete: entry }]


### PR DESCRIPTION
Don't break when we're trying to delete a child record which either doesn't have a parent or doesn't exist at all. In our context, these would be course details of deactivated courses. [Original commit](https://github.com/toptal/chewy/pull/398).